### PR TITLE
docs(README): add special note for shell choice

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ $ repo sync
 ```
 
 ### 5. Compile
+
+> **Note**
+> Use `bash` only. `zsh` is not supported.
+
 ```
 $ source build/cvisetup.sh
 $ defconfig cv1800b_sophpi_duo_sd


### PR DESCRIPTION
zsh:

```
_call_kconfig_script:11: no such file or directory: /path/to/duo/build/scripts/.py
```